### PR TITLE
Revert "Bump kramdown from 2.3.0 to 2.3.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       jekyll (>= 3.8.5)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.1)
+    kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)


### PR DESCRIPTION
Reverts HD-Sec/HD-Sec.github.io#15